### PR TITLE
Añadir opción para activar todos los canales

### DIFF
--- a/ListaDeCanales.cpp
+++ b/ListaDeCanales.cpp
@@ -359,7 +359,6 @@ int ListaDeCanales::buscarPorActivo(bool activo)
 	return encontrados;
 }
 
-
 void ListaDeCanales::ordenarPorNombre()
 {
     if (this->esVacia())
@@ -440,7 +439,8 @@ void ListaDeCanales::menu()
 		cout << "7. Gestionar Por tipo" << endl;
 		cout << "8. Ordenar Canales por Nombre\n";
 		cout << "9. Ordenar Canales por Id\n";
-		cout << "10. Salir" << endl;
+		cout << "10. Activar todos los Canales\n";
+		cout << "11. Salir" << endl;
 		cout << "Ingrese una opcion: ";
 		cin >> opcion;
 		system("cls");
@@ -485,12 +485,19 @@ void ListaDeCanales::menu()
 			system("pause");
 			break;
 		case 10: 
+			activarTodosLosCanales(this->obtenerInicial());
+			escribirEnArchivo();
+			cout << "Canales activados" << endl;
+			system("pause");
+			break;
+		case 11:
+			cout << "Saliendo del menu de canales" << endl;
 			break;
 		default:
 			cout << "Opcion invalida" << endl;
 			break;
 		}
-	} while (opcion != 10);
+	} while (opcion != 11);
 }
 
 
@@ -581,6 +588,16 @@ void ListaDeCanales::desactivarCanal(int id)
 	cout << "Canal desactivado" << endl;
 	system("pause");
 	system("cls");
+}
+
+void ListaDeCanales::activarTodosLosCanales(Nodo<Canal*>* canal)
+{
+    if (canal == nullptr)
+    {
+        return;
+    }
+    canal->getDato()->setActivo(true);
+    activarTodosLosCanales(canal->getSiguiente());
 }
 
 

--- a/ListaDeCanales.h
+++ b/ListaDeCanales.h
@@ -19,7 +19,8 @@ public:
 	void menuParaActualizarCanal(Nodo<Canal*>* canal);
 	void activarCanal(int id);
 	void desactivarCanal(int id);
-
+	//Metodo recursivo para actualizar todos los canales a activo
+	void activarTodosLosCanales(Nodo<Canal*>* canal);
 
 	//Metodos para cargar y escribir en archivo
 	void escribirEnArchivo();


### PR DESCRIPTION
Se ha añadido una nueva opción en el menú de `ListaDeCanales` para activar todos los canales. La opción "Salir" ha sido movida del número 10 al 11. Se ha implementado el método `activarTodosLosCanales` en `ListaDeCanales.cpp` que activa todos los canales de manera recursiva. El bucle `do-while` en el método `menu` se ha actualizado para que continúe hasta que se seleccione la opción 11 (Salir) en lugar de la opción 10. Se ha añadido una llamada al método `activarTodosLosCanales` en el `switch` del menú, junto con la escritura en archivo y un mensaje de confirmación. Se ha añadido la declaración del método `activarTodosLosCanales` en el archivo de cabecera `ListaDeCanales.h`.